### PR TITLE
capture page accessibility tree (most of the time)

### DIFF
--- a/src/htmlsniffer/background.js
+++ b/src/htmlsniffer/background.js
@@ -1,3 +1,54 @@
+async function getActiveTab() {
+  let currTab = undefined;
+  const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
+  if (tabs.length === 0) {
+    console.warn("No active tab found");
+  } else if (!tabs[0].id) {
+    console.warn("Active tab has no ID");
+  } else if (tabs[0].url?.startsWith('chrome://')) {
+      console.warn('Active tab is a chrome:// URL: ' + tabs[0].url);
+  } else {
+    currTab = tabs[0];
+  }
+  return currTab;
+}
+
+async function getActiveTabAxTree() {
+    const currTab = await getActiveTab();
+    if (!currTab) {
+        return undefined;
+    }
+    const target = { tabId: currTab.id };
+    const requiredVersion = "1.3";
+
+    await chrome.debugger.attach(target, requiredVersion);
+
+    const axTree = await chrome.debugger.sendCommand(target, "Accessibility.getFullAXTree", {});
+    //console.info('Accessibility tree:', JSON.stringify(axTree));
+
+    await chrome.debugger.detach(target);
+
+    return axTree;
+}
+
+async function sendDataBatchToLocalBackend(dataBatch, batchType, backendEndpoint) {
+  let axTree = undefined;
+  try {
+    axTree = await getActiveTabAxTree();
+  } catch (error) {
+    console.error('Error getting active tab accessibility tree:', error);
+  }
+  const backendResp = await fetch(`http://localhost:5328/api/browser/${backendEndpoint}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ type: batchType, data: dataBatch, pageAxTree: axTree })
+  });
+  const respMsg = await backendResp.text();
+  console.info(`${batchType} Data batch sent to backend: ${respMsg}`);
+}
+
 // The script listen for messages from content
 chrome.runtime.onMessage.addListener(function (message, sender, sendResponse) {
   // Listen for click messages
@@ -5,43 +56,17 @@ chrome.runtime.onMessage.addListener(function (message, sender, sendResponse) {
     // console.log('Received click event:', message.data);
     sendResponse({ status: 'success', data: 'Click event recorded' });
 
-    // Send click data to server
-    fetch('http://localhost:5328/api/browser/append_element', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({ type: 'click', data: message.data })
-    })
-    .then(response => response.text())
-    .then(data => {
-      console.log('Click data sent to server:', data);
-    })
-    .catch(error => {
-      console.error('Error sending click data:', error);
-    });
-
+    sendDataBatchToLocalBackend(message.data, 'click', 'append_element')
+        .catch(error => console.error('Error sending click data:', error));
   } 
   // Listen for page info messages
   else if (message.type === "pageInfo") {
     // console.log('Received page info:', message.data);
 
-    // Send page info to server
-    fetch('http://localhost:5328/api/browser/append_html', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({ type: 'pageInfo', data: message.data })
-    })
-    .then(response => response.text())
-    .then(data => {
-      console.log('Page info sent to server:', data);
-    })
-    .catch(error => {
-      console.error('Error sending page info:', error);
-    });
+    sendDataBatchToLocalBackend(message.data, 'pageInfo', 'append_html')
+        .catch(error => console.error('Error sending page info data:', error));
 
+    //todo can we please consider not transmitting the large html data back to the content script?
     sendResponse({ status: 'success', data: message.data });
   }
   return true; // Required to keep the sendResponse callback valid

--- a/src/htmlsniffer/content.js
+++ b/src/htmlsniffer/content.js
@@ -6,6 +6,7 @@ let lastUrl = "";
 // Function to check and send page info if HTML or URL changed
 const checkAndSendPageInfo = () => {
   const currentHtml = document.body.innerHTML;
+  const currentPgTitle = document.title;
   const dom = getWebpageState();
   const currentUrl = window.location.href;
 
@@ -17,6 +18,7 @@ const checkAndSendPageInfo = () => {
       html: currentHtml,
       dom: dom,
       url: currentUrl,
+      title: currentPgTitle
     };
     chrome.runtime.sendMessage({ type: "pageInfo", data: pageInfo });
   }

--- a/src/htmlsniffer/content.js
+++ b/src/htmlsniffer/content.js
@@ -4,23 +4,39 @@ let lastHtml = "";
 let lastUrl = "";
 
 // Function to check and send page info if HTML or URL changed
-const checkAndSendPageInfo = () => {
+/**
+ * Check and send page info if HTML or URL changed
+ * @param clickTs ISO timestamp string of a click event that triggered this check for updated page info
+ *                  usually null (for when this is triggered periodically rather than in response to a click)
+ */
+const checkAndSendPageInfo = (clickTs = null) => {
   const currentHtml = document.body.innerHTML;
   const currentPgTitle = document.title;
-  const dom = getWebpageState();
   const currentUrl = window.location.href;
 
+  //todo query- should we also send page info if this is for a click event, even if the url/html are the same as before?
   if (currentUrl !== lastUrl || currentHtml !== lastHtml) {
     lastHtml = currentHtml;
     lastUrl = currentUrl;
 
+    let pageInfoSnapshotStartTs = null;
+    if (clickTs === null) {
+      pageInfoSnapshotStartTs = new Date().toISOString();
+    }
+
+    const dom = getWebpageState();
     const pageInfo = {
       html: currentHtml,
       dom: dom,
       url: currentUrl,
       title: currentPgTitle
     };
-    chrome.runtime.sendMessage({ type: "pageInfo", data: pageInfo });
+    const pageInfoSnapshotEndTs = new Date().toISOString();
+    chrome.runtime.sendMessage(
+      {
+        type: "pageInfo", clickTs: clickTs, pageInfoSnapshotStartTs: pageInfoSnapshotStartTs,
+        pageInfoSnapshotEndTs: pageInfoSnapshotEndTs, data: pageInfo
+      });
   }
 };
 
@@ -34,6 +50,8 @@ setInterval(() => {
 
 // Listen for click events
 document.addEventListener("click", function (event) {
+  const clickTs = new Date().toISOString();
+
   const element = event.target;
   const elementInfo = {
     tag: element.tagName,
@@ -42,8 +60,8 @@ document.addEventListener("click", function (event) {
     text: element.innerText,
   };
   // Send click event to background
-  chrome.runtime.sendMessage({ type: "click", data: elementInfo });
+  chrome.runtime.sendMessage({ type: "click", clickTs: clickTs, data: elementInfo });
 
   // Check and send page info after a click
-  checkAndSendPageInfo();
+  checkAndSendPageInfo(clickTs);
 });

--- a/src/htmlsniffer/manifest.json
+++ b/src/htmlsniffer/manifest.json
@@ -5,7 +5,8 @@
   "permissions": [
     "activeTab",
     "scripting",
-    "storage"
+    "storage",
+    "debugger"
   ],
   "background": {
     "service_worker": "background.js"

--- a/src/htmlsniffer/webpage.js
+++ b/src/htmlsniffer/webpage.js
@@ -91,7 +91,7 @@ function getAllMatchingElements(querySelector, searchRoot = document) {
 
   const elementsDataSegments = [];
 
-  const possibleShadowRootHosts = searchRoot.querySelectorAll("*");
+  const possibleShadowRootHosts = Array.from(searchRoot.querySelectorAll("*"));
   const shadowRootsOfChildren = possibleShadowRootHosts.map(elem => elem.shadowRoot).filter(Boolean);
 
   shadowRootsOfChildren.forEach((shadowRoot) => {


### PR DESCRIPTION
Also fix issue with prior PR's code in content script (forgot NodeListOf didn't have map() and needed to be converted to Array) Sometimes accessibility tree can't be captured because two messages (e.g. a click-triggered message and a once-per-second message) are being handled by the background script at the same time, and the two calls of the background script's message handler are ~simultaneously trying to 'debug' the current tab (which chrome doesn't allow)